### PR TITLE
Remove `<namespace>` from usage unless used

### DIFF
--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -279,8 +279,12 @@ class Manager(object):
 
     @property
     def parser(self):
-        parser = argparse.ArgumentParser(
-            usage='%(prog)s [<namespace>.]<command> [<args>]')
+        if any([c.namespace for c in self.commands.values()]):
+            usage='%(prog)s [<namespace>.]<command> [<args>]'
+        else:
+            usage='%(prog)s <command> [<args>]'
+
+        parser = argparse.ArgumentParser(usage=usage)
         parser.add_argument('command', help='the command to run')
         return parser
 


### PR DESCRIPTION
If there are no namespaces, then remove `<namespace>` from usage text.
